### PR TITLE
Update submit_record.py script to latest version

### DIFF
--- a/red__fitscube_export.pro
+++ b/red__fitscube_export.pro
@@ -488,8 +488,8 @@ pro red::fitscube_export, filename $
       
       ;; Build the command string
       cmd = cmd[0]
-      cmd += ' ' + strlowcase(instrument) ; The dataset ID in the SOLARNET Data Archive/SVO
       cmd += ' ' + outdir+outfile                               ; The FITS file to submit to the SVO
+      cmd += ' --dataset ' + strlowcase(instrument)             ; The dataset ID in the SOLARNET Data Archive/SVO
       cmd += ' --file-url ' + file_url                          ; The URL of the file
       cmd += ' --file-path ' + file_path                        ; The relative path of the file
       if n_elements(thumbnail_url) gt 0 then $                  ;
@@ -497,7 +497,8 @@ pro red::fitscube_export, filename $
       cmd += ' --username ' + svo_username                      ; The SVO username of the user owning the data
       cmd += ' --api-key ' + svo_api_key                        ; The SVO API key of the user owning the data
       cmd += ' --oid ' + oid                                    ; The unique observation ID of the metadata
-      
+      cmd += ' --offline'                                       ; Flag the file as offline
+
       ;; Spawn running the script
       spawn, cmd, status
       print, status

--- a/submit_record.py
+++ b/submit_record.py
@@ -1,86 +1,108 @@
 #!/usr/bin/env python3
+'''Example script for a dataset provider to submit metadata and data location records to the SOLARNET Virtual Observatory (SVO) RESTful API'''
 import os
 import sys
 import argparse
 import logging
 from datetime import datetime
 from urllib.parse import urljoin
+from dateutil.parser import parse, ParserError
 from slumber import API
 from astropy.io import fits
-from requests.auth import AuthBase
 
-# Set with proper base directory of data
-BASE_FILE_DIRECTORY = '/ABSOLUTE/PATH/TO/DATA/DIRECTORY'
-
-# Set with proper base URL of data
+# Set with proper base URL of data, or set file URL explicitly through script argument
 BASE_FILE_URL = 'https://dubshen.astro.su.se/data/'
 
-# Default username and API key of the user in the SOLARNET Data Archive owning the data
-DEFAULT_USERNAME = ''
-DEFAULT_API_KEY = ''
+# The default hdu name or index to use for extracting the metadata from the FITS file (can be specified here to avoid passing it by parameter to the script)
+DEFAULT_FITS_HDU = 0
 
-# Crisp and Chromis data must always be offline to disable download
-DEFAULT_OFFLINE = True
+# If data should be offline by default (can be specified here to avoid passing it by parameter to the script)
+DEFAULT_OFFLINE = False
 
-# URL of the RESTFull API of the SOLARNET Data Archive
+# Default dataset name to use (can be specified here to avoid passing it by parameter to the script)
+DEFAULT_DATASET = None
+
+# Default username and API key of the user in the SVO owning the data (can be specified here to avoid passing it by parameter to the script)
+DEFAULT_USERNAME = None
+DEFAULT_API_KEY = None
+
+# Keyword to use to generate a default oid
+DATE_KEYWORD = 'date_obs'
+
+
+# URL of the SVO RESTful API
 # Don't change this
-SOLARNET_API = 'http://solarnet.oma.be/SDA/api/v1'
+API_URL = 'https://solarnet.oma.be/service/api/svo'
 
-
-class TastypieApiKeyAuth(AuthBase):
-	'''Sets the appropriate authentication headers for the RESTFull API'''
-	def __init__(self, username, api_key):
+class SvoApi(API):
+	'''RESTful API interface for the SVO'''
+	def __init__(self, api_url, username, api_key):
 		self.username = username
 		self.api_key = api_key
+		super().__init__(api_url, auth=self.api_key_auth)
 	
-	def __call__(self, request):
+	def api_key_auth(self, request):
+		'''Sets the API key authentication in the request header'''
 		request.headers['Authorization'] = 'ApiKey %s:%s' % (self.username, self.api_key)
 		return request
+	
+	def __call__(self, resource_uri):
+		'''Return a resource from a resource URI'''
+		return getattr(self, resource_uri)
 
 class Record:
-	def __init__(self, dataset, fits_file, file_url = None, file_path = None, thumbnail_url = None, oid = None, offline = DEFAULT_OFFLINE, username = DEFAULT_USERNAME, api_key = DEFAULT_API_KEY, **kwargs):
-		self.dataset = dataset
+	def __init__(self, fits_file, fits_hdu = DEFAULT_FITS_HDU, file_url = None, file_path = None, thumbnail_url = None, offline = DEFAULT_OFFLINE, oid = None, dataset = DEFAULT_DATASET, username = DEFAULT_USERNAME, api_key = DEFAULT_API_KEY, **kwargs):
 		self.fits_file = fits_file
+		self.fits_hdu = fits_hdu
 		self.file_url = file_url
 		self.file_path = file_path
 		self.thumbnail_url = thumbnail_url
-		self.oid = oid
 		self.offline = offline
-		self.api = API(SOLARNET_API, auth = TastypieApiKeyAuth(username, api_key))
-		self.HDUs = fits.open(self.fits_file)
-		self.fits_header = self.HDUs[0].header
+		self.dataset = dataset
+		self.oid = oid
+		self.api = SvoApi(API_URL, username, api_key)
 	
 	def get_file_url(self):
 		'''Override to return the proper URL for the file'''
 		if self.file_url:
 			return self.file_url
-		else:
+		elif BASE_FILE_URL:
 			return urljoin(BASE_FILE_URL, self.get_file_path())
+		else:
+			raise ValueError('file_url must be provided or BASE_FILE_URL must be set')
 	
 	def get_file_path(self):
 		'''Override to return the proper relative file path for the file'''
 		if self.file_path:
 			return self.file_path
 		else:
-			return os.path.relpath(self.fits_file, BASE_FILE_DIRECTORY)
+			return self.fits_file.lstrip('./')
 	
 	def get_thumbnail_url(self):
 		'''Override to return the proper URL for the thumbnail'''
 		return self.thumbnail_url
 	
-	def get_oid(self):
+	def get_oid(self, metadata = None):
 		'''Override to return the proper OID for the metadata'''
 		if self.oid:
 			return self.oid
+		elif not metadata:
+			raise ValueError('oid or metadata must be provided')
 		else:
-			return datetime.strptime(self.fits_header['DATE-OBS'], '%Y-%m-%dT%H:%M:%S').strftime('%Y%m%d%H%M%S')
+			try:
+				return parse(metadata[DATE_KEYWORD]).strftime('%Y%m%d%H%M%S')
+			except ParserError as why:
+				raise ValueError('Cannot parse keyword "%s" into an oid: %s' % (DATE_KEYWORD, why)) from why
+			except KeyError as why:
+				raise ValueError('Keyword "%s" missing in FITS header, cannot generate default oid' % DATE_KEYWORD) from why
 	
 	def get_data_location(self):
+		'''Return the data_location URI or info for creating a new metadata record'''
 		# If a data_location record for this file already exist, we reuse it
 		# Else we need to create a new one, with all the necessary info
 		
 		# The pair dataset/file_url must be unique in the database so we can search by it
-		data_locations = self.api.data_location.get(dataset = self.dataset, file_url = self.get_file_url())
+		data_locations = self.api.data_location.get(dataset__name = self.dataset, file_url = self.get_file_url())
 		
 		if data_locations['objects']:
 			data_location = data_locations['objects'][0]['resource_uri']
@@ -95,71 +117,78 @@ class Record:
 				'thumbnail_url': self.get_thumbnail_url(),
 				'offline': self.offline,
 			}
-			
-			if self.file_path:
-				data_location['file_path'] = self.file_path
-			else:
-				data_location['file_path'] = os.path.basename(self.fits_file)
-			
-			if self.thumbnail_url:
-				data_location['thumbnail_url'] = self.thumbnail_url
 		
 		return data_location
 	
 	def get_metadata(self):
+		'''Return the metadata info for creating a new metadata record'''
+		
+		with fits.open(self.fits_file) as hdus:
+			fits_header = hdus[self.fits_hdu].header
+		
 		# Create a new metadata record from the FITS file header
 		metadata = {
-			'oid' : self.get_oid(),
-			'fits_header': self.fits_header.tostring()
+			'fits_header': fits_header.tostring().strip()
 		}
 		
-		for keyword in self.api.keyword.get(limit=0, dataset=self.dataset)['objects']:
+		for keyword in self.api.keyword.get(limit=0, dataset__name=self.dataset)['objects']:
 			try:
-				metadata[keyword['db_column']] = self.fits_header[keyword['name']]
+				metadata[keyword['name']] = fits_header[keyword['verbose_name']]
 			except KeyError:
-				logging.warning('Missing keyword "%s" in header, skipping!', keyword['name'])
+				logging.warning('Missing keyword "%s" in header, skipping!', keyword['verbose_name'])
 			else:
-				logging.debug('Header keyword "%s" = "%s"', keyword['name'], metadata[keyword['db_column']])
+				logging.debug('Header keyword "%s" = "%s"', keyword['verbose_name'], metadata[keyword['name']])
+		
+		metadata['oid'] = self.get_oid(metadata)
 		
 		return metadata
 	
-	def submit(self):
-		# Send the metadata and data_location records to the server
+	def create(self):
+		'''Create the metadata and data_location records in the API'''
+		
+		# Retrieve the metadata resource URI from the dataset
+		dataset = self.api.dataset(self.dataset).get()
+		resource_uri = dataset['metadata']['resource_uri']
+		
+		# Get the data to send to the API
 		metadata = self.get_metadata()
 		metadata['data_location'] = self.get_data_location()
-		# Always PUT to the detail URI of the metadata record
-		# to allow creating new record or updating existing one
-		# The detail URI for the metadata record is metadata/{dataset}/{oid}
-		result = self.api.metadata(self.dataset)(metadata['oid']).put(metadata)
-		return result.get('objects')
+		
+		# To create a new record, POST to the resource URI of the metadata record
+		result = self.api(resource_uri).post(metadata)
+		return result
 
 
 
 if __name__ == "__main__":
 
 	# Get the arguments
-	parser = argparse.ArgumentParser(description='Submit meta-data from a FITS file to the SOLARNET Data Archive')
+	parser = argparse.ArgumentParser(description='Submit metadata from a FITS file to the SVO')
 	parser.add_argument('--debug', '-d', action='store_true', help='Set the logging level to debug')
-	parser.add_argument('dataset', help='The dataset ID in the SOLARNET Data Archive')
-	parser.add_argument('fits_file', metavar = 'FITS FILE', help='The FITS file to submit to the SOLARNET Data Archive')
-	parser.add_argument('--file-url', default=argparse.SUPPRESS, help='The URL of the file')
-	parser.add_argument('--file-path', default=argparse.SUPPRESS, help='The relative path of the file')
-	parser.add_argument('--thumbnail-url', default=argparse.SUPPRESS, help='The URL of the thumbnail')
+	parser.add_argument('fits_file', metavar = 'FITS FILE', help='The FITS file to submit to the SVO')
+	parser.add_argument('--fits-hdu', metavar = 'FITS HDU', default=argparse.SUPPRESS, help='The FITS HDU index or name from which to extract the metadata to submit to the SVO')
+	parser.add_argument('--file-url', metavar = 'FILE URL', default=argparse.SUPPRESS, help='The URL of the file')
+	parser.add_argument('--file-path', metavar = 'FILE PATH', default=argparse.SUPPRESS, help='The relative path of the file')
+	parser.add_argument('--thumbnail-url', metavar = 'THUMBNAIL URL', default=argparse.SUPPRESS, help='The URL of the thumbnail')
+	offline_parser = parser.add_mutually_exclusive_group(required=False)
+	offline_parser.add_argument('--offline', dest='offline', default=argparse.SUPPRESS, action='store_true', help='Set the record as offline')
+	offline_parser.add_argument('--online', dest='offline', default=argparse.SUPPRESS, action='store_false', help='Set the record as online (or not offline)')
+	parser.add_argument('--dataset', default=argparse.SUPPRESS, help='The name of the dataset in the SVO')
 	parser.add_argument('--oid', default=argparse.SUPPRESS, help='The unique observation ID of the metadata')
-	parser.add_argument('--username', '-u', default=argparse.SUPPRESS, help='The username of the user owning the data')
+	parser.add_argument('--username', '-u', default=argparse.SUPPRESS, help='The username (email) of the user owning the data')
 	parser.add_argument('--api-key', '-k', default=argparse.SUPPRESS, help='The API key of the user owning the data')
 	
 	args = parser.parse_args()
 	
 	# Setup the logging
 	if args.debug:
-		logging.basicConfig(level = logging.DEBUG, format='%(levelname)-8s: %(message)s')
+		logging.basicConfig(level = logging.DEBUG, format = '%(levelname)-8s: %(funcName)s %(message)s')
 	else:
-		logging.basicConfig(level = logging.INFO, format='%(levelname)-8s: %(message)s')
+		logging.basicConfig(level = logging.INFO, format = '%(levelname)-8s: %(message)s')
 	
 	try:
 		record = Record(**vars(args))
-		result = record.submit()
+		result = record.create()
 	except Exception as why:
 		logging.critical('Could not submit data: %s', why)
 		if getattr(why, 'content', False):


### PR DESCRIPTION
An updated script to submit observations to SOLARNET was provided to us by Benjamin Mampaey. The changes within retarget the submission endpoint to be the latest deployed version of the SOLARNET SVO (`https://solarnet.oma.be/service/api/svo` instead of `http://solarnet.oma.be/SDA/api/v1`).

Small changes to the call site were required to ensure that current functionality was retained.

I tried testing this locally by setting up a local instance of the SVO (in order not to make changes to already submitted data in the live SVO). From what I can tell it updated ingested the data correctly, including having preserved the offline flag. Any other suggestions on specific test scenarios are very welcome.